### PR TITLE
Fix compositions link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 A miscellaneous collection of PF2e macros that I have created for FoundryVTT while using the system.
 
 - [**Learn a Spell**](/macros/learn-a-spell.js) for spellcasters (primarily Wizards).
-- [**Lingering Composition**](/macros/learn-a-spell.js) for extending the duration of an active `Courageous Anthem` buff.
+- [**Lingering Composition**](/macros/performance-compositions.js) for extending the duration of an active `Courageous Anthem` buff.


### PR DESCRIPTION
fixed link to performance-compositions.js, was to learn-a-spell.js